### PR TITLE
Use proc_ops instead of file_operations on Linux >= 5.6

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -5,8 +5,8 @@
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
-#include <asm/uaccess.h>
-#include <acpi/acpi.h>
+#include <linux/acpi.h>
+#include <linux/uaccess.h>
 
 MODULE_LICENSE("GPL");
 
@@ -317,11 +317,18 @@ static ssize_t acpi_proc_read( struct file *filp, char __user *buff,
     return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static struct proc_ops proc_acpi_operations = {
+        .proc_read     = acpi_proc_read,
+        .proc_write    = acpi_proc_write,
+};
+#else
 static struct file_operations proc_acpi_operations = {
         .owner    = THIS_MODULE,
         .read     = acpi_proc_read,
         .write    = acpi_proc_write,
 };
+#endif
 
 #else
 static int acpi_proc_read(char *page, char **start, off_t off,


### PR DESCRIPTION
The proc_create API is changing in Linux 5.6, update code accordingly
See https://github.com/torvalds/linux/commit/d56c0d45f0e27f814e87a1676b6bdccccbc252e9